### PR TITLE
Remove the README links untill the Demos readmes are completed.

### DIFF
--- a/metadata/Configuration/app-custom-ide-ce.json
+++ b/metadata/Configuration/app-custom-ide-ce.json
@@ -3,7 +3,7 @@
         "app-custom-ide-ce": {
             "Label": "app-custom-ide-ce",
             "LastUpdate": {
-                "date": "24/10/2022 at 12:52:02",
+                "date": "27/10/2022 at 15:47:55",
                 "user": "movai"
             },
             "Type": "yaml",

--- a/metadata/Configuration/app-custom-ide-ce.yaml
+++ b/metadata/Configuration/app-custom-ide-ce.yaml
@@ -6,7 +6,7 @@ Examples:
       Detail: The robot moves in a square path of 2mx2m. As time progresses the path shifts due to the accumulative error from the wheel odometry feedback."
     url: global/Flow/husky_simple_navigation
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/husky_simple_navigation"
+    # externalLink: "https://movai-flow.readme.io/reference/husky_simple_navigation"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -18,7 +18,7 @@ Examples:
       Detail: The robot moves in a square path of 2mx2m. As time progresses the path shifts due to the accumulative error from the wheel odometry feedback."
     url: global/Flow/tugbot_simple_navigation
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/tugbot_simple_navigation"
+    # externalLink: "https://movai-flow.readme.io/reference/tugbot_simple_navigation"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -31,7 +31,7 @@ Examples:
       Detail: Use ignition teleop plugin (Topic: /model/husky/cmd_vel) to move the robot around to map the scene. Use ignition publish plugin (Message Type: ignition.msgs.Empty, Topic: /save_map, Message: leave this part empty) to save the map."
     url: global/Flow/husky_mapping
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/husky_mapping"
+    # externalLink: "https://movai-flow.readme.io/reference/husky_mapping"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -44,7 +44,7 @@ Examples:
       Detail: Use ignition teleop plugin (Topic: /model/tugbot/cmd_vel) to move the robot around to map the scene. Use ignition publish plugin (Message Type: ignition.msgs.Empty, Topic: /save_map, Message: leave this part empty) to save the map."
     url: global/Flow/tugbot_mapping
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/tugbot_mapping"
+    # externalLink: "https://movai-flow.readme.io/reference/tugbot_mapping"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -57,7 +57,7 @@ Examples:
       Detail: Use the Command Line property of the map server node on the flow to select the map to be visualized. Visualize the saved map after mapping a scene. In rviz enable the visualize map group on the left menu to view the map. The default map name is new_map. Use the command line property of the map_server to alter the map name to be visualized."
     url: global/Flow/visualize_map
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/visualize_map"
+    # externalLink: "https://movai-flow.readme.io/reference/visualize_map"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -70,7 +70,7 @@ Examples:
       Detail: The robot moves between three locations of the depot map autonomously repeatedly. This flow is a demo for autonomous navigation  using husky robot. We use the depot map combined with amcl and ekf to localize and move_base combined with the global planner and teb local planner as well as the global costmap and local cost map to navigate the robot. In the flow, the go_to node is used to send a goal to the move_base. Once localized the robot will move to a preset location in the map, which can be configured using the parameters of the go_to node."
     url: global/Flow/husky_autonomous_navigation
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/husky_autonomous_navigation"
+    # externalLink: "https://movai-flow.readme.io/reference/husky_autonomous_navigation"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -83,7 +83,7 @@ Examples:
       Detail: The robot moves between three locations of the depot map autonomously repeatedly. This flow is a demo for autonomous navigation using the Tugbot robot. We use the depot map combined with amcl and ekf to localize and move_base combined with global planner and teb local planner as well as global costmap and local cost map to navigate the robot. In the flow the go_to node is used to send a goal to the move_base. Once localized the robot will move to a preset location in the map, which can be configured using the parameters of the go_to node."
     url: global/Flow/tugbot_autonomous_navigation
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/tugbot_autonomous_navigation"
+    # externalLink: "https://movai-flow.readme.io/reference/tugbot_autonomous_navigation"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -96,7 +96,7 @@ Examples:
       Select the Tugbot pick and drop group on the left menu). Detail: Robot moves to pick up area, align and grab the cart, autonomously drop the cart and go to the charging station. This flow demonstrates the pick-and-drop operation using the Tugbot robot. For the alignment of the robot with the cart, we use the back camera and apriltag detector."
     url: global/Flow/tugbot_pick_and_drop
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/tugbot_pick_and_drop"
+    # externalLink: "https://movai-flow.readme.io/reference/tugbot_pick_and_drop"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""
@@ -108,7 +108,7 @@ Examples:
       Detail: Panda arm rotates the joint1 counter-clockwise and then clockwise repeatedly."
     url: global/Flow/panda_hello_world
     scope: Flow
-    externalLink: "https://movai-flow.readme.io/reference/panda_hello_world"
+    # externalLink: "https://movai-flow.readme.io/reference/panda_hello_world"
     externalLinkLabel: "Readme"
     certified: true
     imageDescription: ""


### PR DESCRIPTION
Since the README for the demo is not completed yet and Ron has agreed that we can release it without it, I've disabled the README button on the Example shards. 

**BEFORE**
![image](https://user-images.githubusercontent.com/51120171/198340546-d0192400-9489-4eee-be76-b510b8cd34b2.png)

**AFTER**
![image](https://user-images.githubusercontent.com/51120171/198340054-8ca4c32d-a6ac-428e-9843-8379a552cae6.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch**
- [x] Ensure that the PR title represents the desired changes
- [x] Ensure that the PR description detail the desired changes
- [x] Link to relevant issues in GitHub or Jira
- [ ] ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [ ] ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~


[^note]:
    Put an `x` into the [ ] to show you have filled the information.
    The template comes from https://github.com/MOV-AI/.github/blob/master/.github/pull_request_template.md
    You can override it by creating .github/pull_request_template.md  in your own repository
